### PR TITLE
Add full cozy config; Add securityContext configs; Add liveness/readiness probe config; Add pre-commit hooks; Add Contributing doc; update READMEs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  # update the chart README.md with the comments from values.yaml
+  - repo: https://github.com/norwoodj/helm-docs
+    rev: v1.2.0
+    hooks:
+      - id: helm-docs
+  # helm lint and markdown link verifier
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.22 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
+    hooks:
+      - id: helmlint
+  # detect any secrets that may be committed before they're committed
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.17.0
+    hooks:
+      - id: gitleaks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+To contribute, please make sure to install the [pre-commit](https://pre-commit.com/hooks.html) hooks in the root of the repo by running the following after cloning the repo and changing to the repo dir:
+
+```bash
+pre-commit install
+```
+
+Then you just need to make sure to bump the version in [Chart.yaml](./charts/cozy-stack/Chart.yaml) according to [semver](https://semver.org/#summary).

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # Helm Chart for Cozy
 
-I wanted to try my hand at making a helm chart for Cozy, because why not 🤷 I've got nothing better to do (I absolutely have better things to do but don't want to)
-
-We're using this docker image: https://hub.docker.com/r/cozy/cozy-stack/tags
-which is hosted here: https://github.com/cozy/cozy-stack
+This is a minimal helm chart for cozy.
 
 ## TLDR
 
-You need to have couchDB up and running right now, but I'll probably add a sub-chart for that later.
+As a pre-req, you will need to install [couchDB](https://github.com/apache/couchdb-helm/tree/main/couchdb). Please view the [values.yaml](./charts/cozy-stack/values.yaml) before installing to make sure you don't need to change any default values. There are also some docs generated from the values.yaml in the chart's [README](./charts/cozy-stack/README.md).
 
 ```bash
 helm repo add cozy https://small-hack.github.io/cozy-helm-chart
-helm install cozy/cozy cozy
+helm install cozy/cozy cozy --values values.yaml
 ```
+
+## Notes
+
+We're using a custom docker image sourced from [jessebot/cozy-stack](https://github.com/jessebot/cozy-stack) and pushed to [docker.io/jessebot/cozy-stack](https://hub.docker.com/r/jessebot/cozy-stack/tags).
+
+The official production docker image is sourced from [cozy/cozy-stack](https://github.com/cozy/cozy-stack) and pushed to [docker.io/cozy/cozy-stack](https://hub.docker.com/r/cozy/cozy-stack/tags), but it cannot run as non-root.
+
 
 ## Status
 
-Under heavy development. Will probably be done in a week or two.
+Still maintained and loved. We'd love community PRs for improvements and Issues to identify problems <3

--- a/charts/cozy-stack/Chart.yaml
+++ b/charts/cozy-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cozy-stack/Chart.yaml
+++ b/charts/cozy-stack/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.6.14-48-g2c217fe7d"
+appVersion: "1.6.15-rc5"
 
 maintainers:
   - name: jessebot

--- a/charts/cozy-stack/README.md
+++ b/charts/cozy-stack/README.md
@@ -43,11 +43,23 @@ A Helm chart for Cozy Stack on Kubernetes
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
+| livenessProbe.enabled | bool | `true` | enable liveness probes |
+| livenessProbe.failureThreshold | int | `15` |  |
+| livenessProbe.initialDelaySeconds | int | `10` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `10` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `3552` |  |
+| readinessProbe.enabled | bool | `true` | enable readiness probes |
+| readinessProbe.failureThreshold | int | `15` |  |
+| readinessProbe.initialDelaySeconds | int | `10` |  |
+| readinessProbe.periodSeconds | int | `10` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `10` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext.runAsGroup | int | `3552` |  |

--- a/charts/cozy-stack/README.md
+++ b/charts/cozy-stack/README.md
@@ -1,6 +1,6 @@
 # cozy-stack
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.14-48-g2c217fe7d](https://img.shields.io/badge/AppVersion-1.6.14--48--g2c217fe7d-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.14-48-g2c217fe7d](https://img.shields.io/badge/AppVersion-1.6.14--48--g2c217fe7d-informational?style=flat-square)
 
 A Helm chart for Cozy Stack on Kubernetes
 
@@ -27,8 +27,8 @@ A Helm chart for Cozy Stack on Kubernetes
 | couchdb.user | string | `""` | username to connect to couchdb with |
 | cozy.adminPassphrase | string | `""` | cozy admin user's password. ignored if cozy.existingSecret is set |
 | cozy.existingAdminSecret | string | `""` | existing kubernetes secret containing a key called passphrase |
-| cozy.existingConfigSecret | string | `""` | override the default cozy configuration with your own secret that will be mounted at /etc/cozy/ must contain a key called one of: cozy.yaml, cozy.yaml.local, cozy.yml, cozy.yml.local, cozy.json |
-| cozy.fs_url | string | `""` | file store directory |
+| cozy.existingConfigSecret | string | `""` | override the default cozy configuration with your own secret that will be mounted at {{ Values.cozy.fs_url }}/.cozy must contain a key called one of: cozy.yaml, cozy.yaml.local, cozy.yml, cozy.yml.local, cozy.json |
+| cozy.fs_url | string | `"/var/lib/cozy"` | file system directory see: https://github.com/cozy/cozy-stack/blob/0fe78134b2d09c73813be48274c66ed8582328e6/cozy.example.yaml#L64 |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` | Additional volumes on the output Deployment definition. |
 | fullnameOverride | string | `""` |  |
@@ -47,10 +47,11 @@ A Helm chart for Cozy Stack on Kubernetes
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
-| podSecurityContext | object | `{}` |  |
+| podSecurityContext.fsGroup | int | `3552` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
-| securityContext | object | `{}` |  |
+| securityContext.runAsGroup | int | `3552` |  |
+| securityContext.runAsUser | int | `3552` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/cozy-stack/README.md
+++ b/charts/cozy-stack/README.md
@@ -26,9 +26,10 @@ A Helm chart for Cozy Stack on Kubernetes
 | couchdb.protocol | string | `"http"` | connect to couchdb with either http or https |
 | couchdb.user | string | `""` | username to connect to couchdb with |
 | cozy.adminPassphrase | string | `""` | cozy admin user's password. ignored if cozy.existingSecret is set |
+| cozy.configPath | string | `"/etc/cozy"` | file system directory see: https://github.com/cozy/cozy-stack/blob/0fe78134b2d09c73813be48274c66ed8582328e6/cozy.example.yaml#L64 |
+| cozy.domain | string | `""` | sharing domain for connecting iwth other cozy friends |
 | cozy.existingAdminSecret | string | `""` | existing kubernetes secret containing a key called passphrase |
-| cozy.existingConfigSecret | string | `""` | override the default cozy configuration with your own secret that will be mounted at {{ Values.cozy.fs_url }}/.cozy must contain a key called one of: cozy.yaml, cozy.yaml.local, cozy.yml, cozy.yml.local, cozy.json |
-| cozy.fs_url | string | `"/var/lib/cozy"` | file system directory see: https://github.com/cozy/cozy-stack/blob/0fe78134b2d09c73813be48274c66ed8582328e6/cozy.example.yaml#L64 |
+| cozy.existingConfigSecret | string | `""` | override the default cozy configuration with your own secret that will be mounted at {{ Values.cozy.configPath }} must contain a key called cozy.yaml |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` | Additional volumes on the output Deployment definition. |
 | fullnameOverride | string | `""` |  |
@@ -65,6 +66,7 @@ A Helm chart for Cozy Stack on Kubernetes
 | securityContext.runAsGroup | int | `3552` |  |
 | securityContext.runAsUser | int | `3552` |  |
 | service.port | int | `80` |  |
+| service.targetPort | int | `8080` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |

--- a/charts/cozy-stack/README.md
+++ b/charts/cozy-stack/README.md
@@ -1,6 +1,6 @@
 # cozy-stack
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.14-48-g2c217fe7d](https://img.shields.io/badge/AppVersion-1.6.14--48--g2c217fe7d-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.15-rc5](https://img.shields.io/badge/AppVersion-1.6.15--rc5-informational?style=flat-square)
 
 A Helm chart for Cozy Stack on Kubernetes
 
@@ -30,43 +30,44 @@ A Helm chart for Cozy Stack on Kubernetes
 | cozy.domain | string | `""` | sharing domain for connecting iwth other cozy friends |
 | cozy.existingAdminSecret | string | `""` | existing kubernetes secret containing a key called passphrase |
 | cozy.existingConfigSecret | string | `""` | override the default cozy configuration with your own secret that will be mounted at {{ Values.cozy.configPath }} must contain a key called cozy.yaml |
-| extraVolumeMounts | list | `[]` |  |
+| extraVolumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
 | extraVolumes | list | `[]` | Additional volumes on the output Deployment definition. |
-| fullnameOverride | string | `""` |  |
+| fullnameOverride | string | `""` | Overrides the full name of this chart instead of using the release name everywhere |
 | image.pullPolicy | string | `"IfNotPresent"` | set to Always if you're using the tag: "latest" |
-| image.repository | string | `"cozy/cozy-stack"` |  |
+| image.registry | string | `"docker.io"` | Set the registry for your docker image |
+| image.repository | string | `"jessebot/cozy-stack"` | Set the repository for your cozy docker image. Official production image is cozy/cozy-stack but it cannot run as non-root yet |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| imagePullSecrets | list | `[]` |  |
+| imagePullSecrets | list | `[]` | secrets to pull your docker private docker image |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `"nginx"` |  |
-| ingress.enabled | bool | `true` |  |
+| ingress.enabled | bool | `false` |  |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
-| livenessProbe.enabled | bool | `true` | enable liveness probes |
+| livenessProbe.enabled | bool | `true` | enable liveness probes Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes |
 | livenessProbe.failureThreshold | int | `15` |  |
 | livenessProbe.initialDelaySeconds | int | `10` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `10` |  |
-| nameOverride | string | `""` |  |
+| nameOverride | string | `""` | Overrides the name of this chart instead of using the release name everywhere |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
-| podSecurityContext.fsGroup | int | `3552` |  |
-| readinessProbe.enabled | bool | `true` | enable readiness probes |
+| podSecurityContext.fsGroup | int | `3552` | group to chown volumes to. If using the production cozy/cozy-stack image, you may need to set this 0 to run as root |
+| readinessProbe.enabled | bool | `true` | enable readiness probes Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes |
 | readinessProbe.failureThreshold | int | `15` |  |
 | readinessProbe.initialDelaySeconds | int | `10` |  |
 | readinessProbe.periodSeconds | int | `10` |  |
 | readinessProbe.successThreshold | int | `1` |  |
 | readinessProbe.timeoutSeconds | int | `10` |  |
-| replicaCount | int | `1` |  |
+| replicaCount | int | `1` | how many pods to deploy of cozy |
 | resources | object | `{}` |  |
-| securityContext.runAsGroup | int | `3552` |  |
-| securityContext.runAsUser | int | `3552` |  |
+| securityContext.runAsGroup | int | `3552` | runAsGroup for the cozy container. If using the production cozy/cozy-stack image, you may need to set this 0 to run as root |
+| securityContext.runAsUser | int | `3552` | runAsUser for the cozy container. If using the production cozy/cozy-stack image, you may need to set this 0 to run as root |
 | service.port | int | `80` |  |
-| service.targetPort | int | `8080` |  |
+| service.targetPort | int | `8080` | this is the target port on the container |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -36,11 +36,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - "cozy-stack"
-            - "serve"
-            - "--config"
-            - "{{ .Values.cozy.configPath }}/cozy.yaml"
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -72,6 +67,7 @@ spec:
           volumeMounts:
             - name: cozy-config
               mountPath: {{ .Values.cozy.configPath }}
+              subPath: cozy.yaml.local
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -36,11 +36,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - "cozy-stack"
-            - "serve"
-            - "--config"
-            - "{{ .Values.cozy.configPath }}/cozy.yaml.local"
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -36,6 +36,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "cozy-stack"
+            - "serve"
+            - "--config"
+            - "{{ .Values.cozy.configPath }}/cozy.yaml.local"
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -36,6 +36,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "cozy-stack"
+            - "serve"
+            - "--config"
+            - "{{ .Values.cozy.configPath }}/cozy.yaml"
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: cozy-config
-              mountPath: {{ .Values.cozy.configPath }}
+              mountPath: {{ .Values.cozy.configPath }}/cozy.yaml.local
               subPath: cozy.yaml.local
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -102,6 +102,8 @@ spec:
                 secretKeyRef:
                   name: "{{ template "cozy.admin.secret" . }}"
                   key: passphrase
+            - name: COZY_HOST
+              value: {{ .Values.cozy.domain }}
       volumes:
         - name: cozy-config
           secret:

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -40,14 +40,28 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
             httpGet:
               path: /
-              port: http
+              port: 8080
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
             httpGet:
               path: /
-              port: http
+              port: 8080
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
@@ -48,7 +48,7 @@ spec:
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             httpGet:
-              path: /
+              path: /status
               port: 8080
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
@@ -59,7 +59,7 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             httpGet:
-              path: /
+              path: /status
               port: 8080
           {{- end }}
           resources:

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: cozy-config
-              mountPath: {{ .Values.cozy.fs_url }}/.cozy
+              mountPath: {{ .Values.cozy.configPath }}
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: cozy-config
-              mountPath: /etc/cozy
+              mountPath: {{ .Values.cozy.fs_url }}/.cozy
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -102,8 +102,6 @@ spec:
                 secretKeyRef:
                   name: "{{ template "cozy.admin.secret" . }}"
                   key: passphrase
-            - name: COZY_HOST
-              value: {{ .Values.cozy.domain }}
       volumes:
         - name: cozy-config
           secret:

--- a/charts/cozy-stack/templates/deployment.yaml
+++ b/charts/cozy-stack/templates/deployment.yaml
@@ -66,8 +66,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: cozy-config
-              mountPath: {{ .Values.cozy.configPath }}/cozy.yaml.local
-              subPath: cozy.yaml.local
+              mountPath: {{ .Values.cozy.configPath }}/cozy.yaml
+              subPath: cozy.yaml
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/cozy-stack/templates/secret-cozy-config.yaml
+++ b/charts/cozy-stack/templates/secret-cozy-config.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: cozy-config-secret
 stringData:
-  cozy.yaml.local: |
+  cozy.yaml: |
     # couchdb parameters
     host: 0.0.0.0
     # server port - flags: --port -p

--- a/charts/cozy-stack/templates/secret-cozy-config.yaml
+++ b/charts/cozy-stack/templates/secret-cozy-config.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: cozy-config-secret
 stringData:
-  cozy.yaml.local: |
+  .cozy.yaml: |
     # couchdb parameters
     couchdb:
       # CouchDB URL - flags: --couchdb-url

--- a/charts/cozy-stack/templates/secret-cozy-config.yaml
+++ b/charts/cozy-stack/templates/secret-cozy-config.yaml
@@ -6,7 +6,393 @@ metadata:
 stringData:
   cozy.yaml.local: |
     # couchdb parameters
+    host: 0.0.0.0
+    # server port - flags: --port -p
+    port: 8080
+
+    # how to structure the subdomains for apps - flags: --subdomains
+    # values:
+    #  - nested, like https://<app>.<user>.<domain>/ (well suited for self-hosted with Let's Encrypt)
+    #  - flat, like https://<user>-<app>.<domain>/ (easier when using wildcard TLS certificate)
+    subdomains: nested
+
+    # defines a list of assets that can be fetched via the /remote/:asset-name
+    # route.
+    remote_assets:
+      bank: https://myassetserver.com/remote_asset.json
+
+    # path to the directory with the assets - flags: --assets
+    # default is to use the assets packed in the binary
+    # assets: ""
+
+    # administration endpoint parameters. this endpoint should be protected
+    admin:
+      # server host - flags: --admin-host
+      host: 0.0.0.0
+      # server port - flags: --admin-port
+      port: 6060
+      # secret file name containing the derived passphrase to access to the
+      # administration endpoint. this secret file can be generated using the `cozy-
+      # stack config passwd` command. this file should be located in the same path
+      # as the configuration file.
+      secret_filename: cozy-admin-passphrase
+
+    # vault contains keyfiles informations
+    # See https://docs.cozy.io/en/cozy-stack/cli/cozy-stack_config_gen-keys/
+    # to generate the keys
+    vault:
+      # the path to the key used to encrypt credentials
+      credentials_encryptor_key: /etc/cozy/vault.enc
+      # the path to the key used to decrypt credentials
+      credentials_decryptor_key: /etc/cozy/vault.dec
+
+    # file system parameters
+    fs:
+
+    # couchdb parameters
     couchdb:
       # CouchDB URL - flags: --couchdb-url
-      url: {{ `{{ .Env.COUCHDB_PROTOCOL }}` }}://{{ `{{ .Env.COUCHDB_HOST }}` }}:{{ `{{ .Env.COUCHDB_PORT }}` }}/
+      url: {{ `{{ .Env.COUCHDB_PROTOCOL }}` }}://{{ `{{ .Env.COUCHDB_USER }}` }}:{{ `{{ .Env.COUCHDB_PASSWORD }}` }}@{{ `{{ .Env.COUCHDB_HOST }}` }}:{{ `{{ .Env.COUCHDB_PORT }}` }}/
+
+      # CouchDB advanced parameters to activate TLS properties:
+      #
+      # root_ca: /ca-certificates.pem
+      # client_cert: /client_cert.pem
+      # client_key: /client_key
+      # pinned_key: 57c8ff33c9c0cfc3ef00e650a1cc910d7ee479a8bc509f6c9209a7c2a11399d6
+      # insecure_skip_validation: true
+
+      # Multiple CouchDB clusters:
+      # clusters:
+      #   - url: http://couchdb1:5984/
+      #     instance_creation: true
+      #   - url: http://couchdb2:5984/
+      #     instance_creation: false
+      #   - url: http://couchdb3:5984/
+      #     instance_creation: true
+
+    # jobs parameters to configure the job system
+    jobs:
+      # path to the imagemagick convert binary
+      # imagemagick_convert_cmd: convert
+
+      # Specify whether the given list of jobs is an allowlist or blocklist. In case
+      # of an allowlist, all jobs are deactivated by default and only the listed one
+      # are activated.
+      #
+      # allowlist: false
+
+      # workers individual configrations.
+      #
+      # For each worker type it is possible to configure the following fields:
+      #   - concurrency: the maximum number of jobs executed in parallel. when set
+      #     to zero, the worker is deactivated
+      #   - max_exec_count: the maximum number of retries for one job in case of an
+      #     error
+      #   - timeout: the maximum amount of time allowed for one execution of a job
+      #
+      # List of available workers:
+      #
+      #   - "clean-clients":     delete unused OAuth clients
+      #   - "export":            exporting data from a cozy instance
+      #   - "import":            importing data into a cozy instance
+      #   - "konnector":         launching konnectors
+      #   - "service":           launching services
+      #   - "migrations":        transforming a VFS with Swift to layout v3
+      #   - "notes-save":        saving notes to the VFS
+      #   - "push":              sending push notifications
+      #   - "sms":               sending SMS notifications
+      #   - "sendmail":          sending mails
+      #   - "share-replicate":   for cozy to cozy sharing
+      #   - "share-track":       idem
+      #   - "share-upload":      idem
+      #   - "thumbnail":         creatings and deleting thumbnails for images
+      #   - "thumbnailck":       generate missing thumbnails for all images
+      #   - "trash-files":       async deletion of files in the trash
+      #   - "clean-old-trashed": deletion of old files and directories after some time
+      #   - "unzip":             unzipping tarball
+      #   - "zip":               creating a zip tarball
+      #
+      # When no configuration is given for a worker, a default configuration is
+      # used. When a false boolean value is given, the worker is deactivated.
+      #
+      # To deactivate all workers, the workers field can be set to "false" or
+      # "none".
+      workers:
+
+      # Sets the default duration of jobs database documents to keep
+      defaultDurationToKeep: "2W" # Keep 2 weeks
+
+    # konnectors execution parameters for executing external processes.
+    konnectors:
+      cmd: ./scripts/konnector-node-run.sh # run connectors with node
+      # cmd: ./scripts/konnector-node-run.sh # run connectors with node in dev mode
+      # cmd: ./scripts/konnector-rkt-run.sh # run connectors with rkt
+      # cmd: ./scripts/konnector-nsjail-node8-run.sh # run connectors with nsjail
+
+    # mail service parameters for sending email via SMTP
+    mail:
+      # mail noreply address - flags: --mail-noreply-address
+      noreply_address: noreply@localhost
+      noreply_name: My Cozy
+      reply_to: support@cozycloud.cc
+      # mail smtp host - flags: --mail-host
+      host: smtp.home
+      # mail smtp port - flags: --mail-port
+      port: 587
+      # mail smtp username - flags: --mail-username
+      username: {{ `{{.Env.COZY_MAIL_USERNAME}}` }}
+      # mail smtp password - flags: --mail-password
+      password: {{ `{{.Env.COZY_MAIL_PASSWORD}}` }}
+      # Use SSL connection (SMTPS)
+      # Means no STARTTLS
+      # flags: --mail-use-ssl
+      use_ssl: false
+      # disable mail STARTTLS
+      # Means using plain unencrypted SMTP
+      # flags: --mail-disable-tls
+      disable_tls: false
+      # skip the certificate validation (may be useful on localhost)
+      skip_certificate_validation: false
+      # Local Name
+      # The hostname sent to the SMTP server with the HELO command
+      # Defaults to localhost
+      # flags: --mail-local-name
+      local_name: cozy.domain.example
+      # It is also possible to override the mail server per context.
+      contexts:
+        beta:
+          # If the host is set to "-", no mail will be sent on this context
+          host: smtp.cozy.beta
+          port: 587
+          username: {{ `{{.Env.COZY_BETA_MAIL_USERNAME}}` }}
+          password: {{ `{{.Env.COZY_BETA_MAIL_PASSWORD}}` }}
+
+    # location of the database for IP -> City lookups - flags: --geodb
+    # See https://dev.maxmind.com/geoip/geoip2/geolite2/
+    geodb: ""
+
+    # minimal duration between two password reset
+    password_reset_interval: 15m
+
+    # redis namespace to configure its usage for different part of the stack. redis
+    # is not mandatory and is specifically useful to run the stack in an
+    # environment where multiple stacks run simultaneously.
+    redis:
+      # the redis clients created can be configured to be used with a cluster of
+      # redis. if addrs field is left empty, redis is not used.
+
+      # either a single address or a seed list of host:port addresses
+      # of cluster/sentinel nodes separated by whitespaces.
+      addrs: # localhost:1234 localhost:4321
+
+      # the sentinel master name - only failover clients.
+      master:
+
+      # redis password
+      password:
+
+      # databases number for each part of the stack using a specific database.
+      databases:
+        jobs: 0
+        cache: 1
+        lock: 2
+        sessions: 3
+        downloads: 4
+        konnectors: 5
+        realtime: 6
+        log: 7
+        rate_limiting: 8
+
+      # advanced parameters for advanced users
+
+      # dial_timeout: 5s
+      # read_timeout: 3s
+      # write_timeout: 3s
+      # pool_size: max(25, 10 * runtime.NumCPU())  # pool_size cannot be below 25
+      # pool_timeout: 3s
+      # idle_timeout: 5m
+
+      # enables read only queries on slave nodes.
+      # read_only_slave: false
+
+    # Registries used for applications and konnectors
+    registries:
+      default:
+        - https://apps-registry.cozycloud.cc/
+
+    # Wizard used for moving a Cozy from one place/hoster to another
+    move:
+      url: https://move.cozycloud.cc/
+
+    # OnlyOffice server for collaborative edition of office documents
+    office:
+      default:
+        onlyoffice_url: https://documentserver.cozycloud.cc/
+        onlyoffice_inbox_secret: inbox_secret
+        onlyoffice_outbox_secret: outbox_secret
+
+    # [internal usage] Cloudery configuration
+    clouderies:
+      default:
+        api:
+          url: https://manager.cozycloud.cc/
+          token: xxxxxx
+
+    # All the deprecated apps listed here will see their OAUTH2 Authorization
+    # flow interupted and redirected to a page proposing to move to the new
+    # cozy application.
+    #
+    # The keys for `store_urls` can be: iphone/android/other
+    deprecated_apps:
+      apps:
+    #     - software_id: "github.com/cozy/some-app"
+    #       name: "some-app"
+    #       store_urls:
+    #         iphone: https://some-apple-store-url
+    #         android: https://some-android-store-url
+
+    notifications:
+      # Activate development APIs (iOS only)
+      development: false
+
+      # Firebase Cloud Messaging API Key for Android notifications
+      # android_api_key: ""
+      # Use this key to run end to test with a fake FCM server
+      # fcm_server: "http://localhost:3001"
+
+      # APNS/2 certificates for iOS notifications
+      # ios_certificate_key_path: path/to/certificate.p12
+      # ios_certificate_password: mycertificatepasswordifany
+      # ios_key_id: my_key_id_if_any
+      # ios_team_id: my_team_id_if_any
+
+      # Huawei notifications
+      # huawei_get_token: http://localhost:3001/api/notification-token/huawei
+      # huawei_send_message: https://push-api.cloud.huawei.com/v1/<your_appid>/messages:send
+
+      # Configure the SMS per context
+      contexts:
+        beta:
+          provider: api_sen
+          url: https://sms.cozy.beta/api/send
+          token: {{ `{{.Env.COZY_BETA_SMS_TOKEN}}` }}
+
+    flagship:
+      contexts:
+        cozy_beta:
+          skip_certification: true
+      apk_package_names:
+        - io.cozy.drive.mobile
+        - io.cozy.flagship.mobile
+      apk_certificate_digests:
+        - 'xNnH7T1BSDh6erMzNysfakBVLLacbSbOMxVk8jEPgdU='
+      apple_app_ids:
+        - 3AKXFMV43J.io.cozy.drive.mobile
+        - 3AKXFMV43J.io.cozy.flagship.mobile
+
+    # Allowed domains for the CSP policy used in hosted web applications
+    csp_allowlist:
+      # script: https://allowed1.domain.com/ https://allowed2.domain.com/
+      # img:    https://allowed.domain.com/
+      # style:  https://allowed.domain.com/
+      # font:   https://allowed.domain.com/
+
+      # It is also possible to configure the CSP policy per context. The values are
+      # cumulative with the global csp allowlist.
+      contexts:
+        beta:
+          img: https://allowed2.domain.com/
+
+    # It can useful to disable the CSP policy to debug and test things in local
+    # disable_csp: true
+
+    log:
+      # logger level (debug, info, warning, panic, fatal) - flags: --log-level
+      level: info
+      # send logs to the local syslog - flags: --log-syslog
+      syslog: false
+
+    # It is possible to customize some behaviors of cozy-stack in function of the
+    # context of an instance (the context field of the settings document of this
+    # instance). Here, the "beta" context is customized with.
+    contexts:
+      beta:
+        # Indicates if debug related features should be enabled in front
+        # applications.
+        debug: false
+        # Redirect to a specific route of Cozy-Home after the onboarding
+        # Format: appslug/#/path/to/route
+        onboarded_redirection: home/#/discovery/?intro
+        # Redirect to the photos application after login
+        default_redirection: drive/#/folder
+        # This domain will be used as a suggestion for the members of a sharing
+        # when they are asked for the URL of their Cozy instance
+        sharing_domain: mycozy.cloud
+        # Allow to customize the cozy-bar link to the help
+        help_link: https://forum.cozy.io/
+        # claudy actions list
+        claudy_actions:
+          - desktop
+          - mobile
+        # konnectors slugs to exclude from cozy-collect
+        exclude_konnectors:
+          - a_konnector_slug
+        # If enabled, this option will skip permissions verification during
+        # webapp/konnectors installs & updates processes
+        permissions_skip_verification: false
+        # By default, only the store app can install and update applications. But,
+        # if this setting is enabled, it allows other applications with the right
+        # permission to install and update applications.
+        allow_install_via_a_permission: true
+        # Tells if the photo folder should be created or not during the instance
+        # creation (default: true)
+        init_photos_folder: true
+        # Tells if the administrative folder should be created or not during the
+        # instance creation (default: true)
+        init_administrative_folder: true
+        # Allows to override the default template "Cozy" title by your own title
+        templates_title: "My Personal Cloud"
+        # Use a different noreply mail for this context
+        noreply_address: noreply@cozy.beta
+        noreply_name: My Cozy Beta
+        reply_to: support@cozy.beta
+        # Configure the error page
+        support_address: support@cozy.beta
+        # Change the limit on the number of members for a sharing
+        max_members_per_sharing: 50
+        # Use a different wizard for moving a Cozy
+        move_url: htts://move.cozy.beta/
+        # Feature flags
+        features:
+          - hide_konnector_errors
+        # List of applications that can be automatically updated even if the
+        # permissions have changed
+        additional_platform_apps:
+          - superapp
+        # Provides custom logo used in some cozy app (e.g. Home footer)
+        # Use type key if you want defined a logo as main
+        logos:
+          coachco2:
+            light:
+              - src: /logos/main_cozy.png
+                alt: Cozy Cloud
+            dark:
+              - src: /logos/main_cozy.png
+                alt: Cozy Cloud
+          home:
+            light:
+              - src: /logos/main_cozy.png
+                alt: Cozy Cloud
+                type: main
+              - src: /logos/1_partner.png
+                alt: Partner n°1
+                type: secondary
+            dark:
+              - src: /logos/main_cozy.png
+                alt: Cozy Cloud
+                type: main
+              - src: /logos/1_partner.png
+                alt: Partner n°1
+                type: secondary
 {{- end }}

--- a/charts/cozy-stack/templates/secret-cozy-config.yaml
+++ b/charts/cozy-stack/templates/secret-cozy-config.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: cozy-config-secret
 stringData:
-  .cozy.yaml: |
+  cozy.yaml: |
     # couchdb parameters
     couchdb:
       # CouchDB URL - flags: --couchdb-url

--- a/charts/cozy-stack/templates/secret-cozy-config.yaml
+++ b/charts/cozy-stack/templates/secret-cozy-config.yaml
@@ -328,7 +328,7 @@ stringData:
         default_redirection: drive/#/folder
         # This domain will be used as a suggestion for the members of a sharing
         # when they are asked for the URL of their Cozy instance
-        sharing_domain: mycozy.cloud
+        sharing_domain: {{ .Values.cozy.domain }}
         # Allow to customize the cozy-bar link to the help
         help_link: https://forum.cozy.io/
         # claudy actions list

--- a/charts/cozy-stack/templates/secret-cozy-config.yaml
+++ b/charts/cozy-stack/templates/secret-cozy-config.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: cozy-config-secret
 stringData:
-  cozy.yaml: |
+  cozy.yaml.local: |
     # couchdb parameters
     couchdb:
       # CouchDB URL - flags: --couchdb-url

--- a/charts/cozy-stack/templates/service.yaml
+++ b/charts/cozy-stack/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: 8080
       protocol: TCP
       name: http
   selector:

--- a/charts/cozy-stack/templates/service.yaml
+++ b/charts/cozy-stack/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: 8080
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
   selector:

--- a/charts/cozy-stack/values.yaml
+++ b/charts/cozy-stack/values.yaml
@@ -70,6 +70,7 @@ securityContext:
 
 service:
   type: ClusterIP
+  targetPort: 8080
   port: 80
 
 ingress:

--- a/charts/cozy-stack/values.yaml
+++ b/charts/cozy-stack/values.yaml
@@ -2,17 +2,26 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- how many pods to deploy of cozy
 replicaCount: 1
 
 image:
-  repository: cozy/cozy-stack
+  # -- Set the registry for your docker image
+  registry: docker.io
+  # -- Set the repository for your cozy docker image.
+  # Official production image is cozy/cozy-stack but it cannot run as non-root yet
+  repository: jessebot/cozy-stack
   # -- set to Always if you're using the tag: "latest"
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# -- secrets to pull your docker private docker image
 imagePullSecrets: []
+
+# -- Overrides the name of this chart instead of using the release name everywhere
 nameOverride: ""
+# -- Overrides the full name of this chart instead of using the release name everywhere
 fullnameOverride: ""
 
 cozy:
@@ -59,10 +68,13 @@ podAnnotations: {}
 podLabels: {}
 
 podSecurityContext:
+  # -- group to chown volumes to. If using the production cozy/cozy-stack image, you may need to set this 0 to run as root
   fsGroup: 3552
 
 securityContext:
+  # -- runAsUser for the cozy container. If using the production cozy/cozy-stack image, you may need to set this 0 to run as root
   runAsUser: 3552
+  # -- runAsGroup for the cozy container. If using the production cozy/cozy-stack image, you may need to set this 0 to run as root
   runAsGroup: 3552
   # capabilities:
   #   drop:
@@ -72,22 +84,60 @@ securityContext:
 
 service:
   type: ClusterIP
+  # -- this is the target port on the container
   targetPort: 8080
   port: 80
 
 ingress:
-  enabled: true
+  enabled: false
   className: "nginx"
   annotations: {}
+  # for ingress hosts for cozy, you'll need an ingress per app, e.g.
+  #   home.cozy.example.com, settings.cozy.example.com etc
+  # learn more here: https://docs.cozy.io/en/tutorials/selfhosting/finalize/nginx/
+  # if this is exposed to the internet/intranet make sure to also setup your DNS records like:
+  #   cozy     1h     IN         A     <your_server_IP>
+  #   *.cozy   1h     IN       CNAME     cozy
+  #
+  # example using example.com as the core domain:
+  #   cozy.example.com     1h     IN         A       42.42.20.24
+  #   *.cozy.example.com   1h     IN       CNAME     cozy
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
+    #
+    # - host: settings.chart-example.local
+    #   paths:
+    #     - path: /
+    #       pathType: ImplementationSpecific
+    #
+    # - host: home.chart-example.local
+    #   paths:
+    #     - path: /
+    #       pathType: ImplementationSpecific
+    #
+    # - host: drive.chart-example.local
+    #   paths:
+    #     - path: /
+    #       pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  #
+  #  - secretName: settings-chart-example-tls
+  #    hosts:
+  #      - settings.chart-example.local
+  #
+  #  - secretName: home-chart-example-tls
+  #    hosts:
+  #      - home.chart-example.local
+  #
+  #  - secretName: drive-chart-example-tls
+  #    hosts:
+  #      - drive.chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -115,7 +165,7 @@ extraVolumes: []
 #     secretName: mysecret
 #     optional: false
 
-# Additional volumeMounts on the output Deployment definition.
+# -- Additional volumeMounts on the output Deployment definition.
 extraVolumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"
@@ -129,10 +179,10 @@ affinity: {}
 
 
 ## Liveness and readiness probe values
-## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 ##
 livenessProbe:
   # -- enable liveness probes
+  # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   enabled: true
   initialDelaySeconds: 10
   periodSeconds: 10
@@ -142,6 +192,7 @@ livenessProbe:
 
 readinessProbe:
   # -- enable readiness probes
+  # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   enabled: true
   initialDelaySeconds: 10
   periodSeconds: 10

--- a/charts/cozy-stack/values.yaml
+++ b/charts/cozy-stack/values.yaml
@@ -123,3 +123,25 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+
+## Liveness and readiness probe values
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+##
+livenessProbe:
+  # -- enable liveness probes
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 15
+  successThreshold: 1
+
+readinessProbe:
+  # -- enable readiness probes
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 15
+  successThreshold: 1

--- a/charts/cozy-stack/values.yaml
+++ b/charts/cozy-stack/values.yaml
@@ -22,9 +22,11 @@ cozy:
   existingAdminSecret: ""
   # -- file system directory
   # see: https://github.com/cozy/cozy-stack/blob/0fe78134b2d09c73813be48274c66ed8582328e6/cozy.example.yaml#L64
-  configPath: "/var/lib/cozy"
+  configPath: "/etc/cozy"
+  # -- sharing domain for connecting iwth other cozy friends
+  domain: ""
   # -- override the default cozy configuration with your own secret that will be mounted at {{ Values.cozy.configPath }}
-  # must contain a key called one of: cozy.yaml, cozy.yaml.local, cozy.yml, cozy.yml.local, cozy.json
+  # must contain a key called cozy.yaml
   existingConfigSecret: ""
 
 couchdb:

--- a/charts/cozy-stack/values.yaml
+++ b/charts/cozy-stack/values.yaml
@@ -22,8 +22,8 @@ cozy:
   existingAdminSecret: ""
   # -- file system directory
   # see: https://github.com/cozy/cozy-stack/blob/0fe78134b2d09c73813be48274c66ed8582328e6/cozy.example.yaml#L64
-  fs_url: "/var/lib/cozy"
-  # -- override the default cozy configuration with your own secret that will be mounted at {{ Values.cozy.fs_url }}/.cozy
+  configPath: "/var/lib/cozy"
+  # -- override the default cozy configuration with your own secret that will be mounted at {{ Values.cozy.configPath }}
   # must contain a key called one of: cozy.yaml, cozy.yaml.local, cozy.yml, cozy.yml.local, cozy.json
   existingConfigSecret: ""
 

--- a/charts/cozy-stack/values.yaml
+++ b/charts/cozy-stack/values.yaml
@@ -20,9 +20,10 @@ cozy:
   adminPassphrase: ""
   # -- existing kubernetes secret containing a key called passphrase
   existingAdminSecret: ""
-  # -- file store directory
-  fs_url: ""
-  # -- override the default cozy configuration with your own secret that will be mounted at /etc/cozy/
+  # -- file system directory
+  # see: https://github.com/cozy/cozy-stack/blob/0fe78134b2d09c73813be48274c66ed8582328e6/cozy.example.yaml#L64
+  fs_url: "/var/lib/cozy"
+  # -- override the default cozy configuration with your own secret that will be mounted at {{ Values.cozy.fs_url }}/.cozy
   # must contain a key called one of: cozy.yaml, cozy.yaml.local, cozy.yml, cozy.yml.local, cozy.json
   existingConfigSecret: ""
 
@@ -55,16 +56,17 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 3552
 
-securityContext: {}
+securityContext:
+  runAsUser: 3552
+  runAsGroup: 3552
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
-  # runAsUser: 1000
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Description

We've added a number of small-but-useful features and fixes:

- defaults to the our custom docker image that can run as non-root users
- Added full cozy configMap using the example cozy.yaml (with minimal tweaks for using this on k8s via helm)
- Added config path to values.yaml
- Added securityContext and podSecurityContext configs to values.yaml (as well as the ability to turn them off)
- Added liveness/readiness probe
- Addded pre-commit hooks for generating helm-docs
- Add Contributing doc for anyone who wants to help out
- update READMEs with notes about our custom docker image
- made both the service port and targetPort configurable via values.yaml


## Notes
We're using a custom docker image sourced from [jessebot/cozy-stack](https://github.com/jessebot/cozy-stack) and pushed to [docker.io/jessebot/cozy-stack](https://hub.docker.com/r/jessebot/cozy-stack/tags).

The official production docker image is sourced from [cozy/cozy-stack](https://github.com/cozy/cozy-stack), but it cannot run as non-root. To use the official image, you can set `image.repository` to "cozy/cozy-stack" and the tag to any tag listed on [hub.docker.com:cozy/cozy-stack/tags](https://hub.docker.com/r/cozy/cozy-stack/tags). You'll also need to set the `securityContext.runAsUser` to `0`.

The default ingress is not disabled, and there's some notes about how to use it now, but here's an example values.yaml anyway:

```yaml
ingress:
  enabled: true
  className: "nginx"
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-staging
  # for ingress hosts for cozy, you'll need an ingress per app
  hosts:
    - host: cozy.example.com
      paths:
        - path: /
          pathType: ImplementationSpecific
    
     - host: settings.cozy.example.com
       paths:
         - path: /
           pathType: ImplementationSpecific
    
     - host: home.cozy.example.com
       paths:
         - path: /
           pathType: ImplementationSpecific

    - host: drive.cozy.example.com
       paths:
         - path: /
           pathType: ImplementationSpecific
  tls:
    - secretName: example-tls
      hosts:
        - cozy.example.com
  
    - secretName: settings-example-tls
      hosts:
        - settings.cozy.example.com
  
    - secretName: home-example-tls
      hosts:
        - home.cozy.example.com
  
    - secretName: drive-example-tls
      hosts:
        - drive.cozy.example.com
```


If this is exposed to the internet/intranet make sure to also setup your DNS records like:

```
cozy.example.com     1h     IN         A       42.42.20.24
*.cozy.example.com   1h     IN       CNAME     cozy
```  
  
Learn more here: https://docs.cozy.io/en/tutorials/selfhosting/finalize/nginx/